### PR TITLE
Removed Speed 100 post hyper

### DIFF
--- a/worlds/plugins/LotJFlight.xml
+++ b/worlds/plugins/LotJFlight.xml
@@ -331,7 +331,6 @@ end
 
 function coursePlanet()
   hyperCompleted = true
-	Send("speed 100")
 	Send("course '" .. planetName .. "'")
 end
 


### PR DESCRIPTION
(ID: 1791) Minor Bug Fixes 11/26/2020
-----------------------
- Ships no longer overshoot orbiting a planet when their speed is over 100.

This function is no longer needed and slows down space travel unnecessarily.