### PR TITLE
Change 256color regex to narrow grab.

### DIFF
--- a/worlds/plugins/lotj_colors.lua
+++ b/worlds/plugins/lotj_colors.lua
@@ -230,7 +230,7 @@ function strip_colours (s)
    s = s:gsub ("&%-", "~")    -- fix tildes
    s = s:gsub ("&&", "\0")  -- change && to 0x00
    s = s:gsub ("&[^xcmyrgbwCMYRGBWD]", "")  -- rip out hidden garbage
-   s = s:gsub ("&%d?%d?%d?", "") -- strip xterm color codes
+   s = s:gsub ("&%d{3}", "") -- strip xterm color codes
    s = s:gsub ("&%a([^&]*)", "%1") -- strip normal color codes
    return (s:gsub ("%z", "&")) -- put & back
 end -- strip_colours


### PR DESCRIPTION
Previously this would eat everything from `&` to `&1` to `&123` -- with the new, it only eats the `&` if it's followed by three digits.

Kinda wish we had a unit test suite for this, but I think this is accurate.  Please test to confirm.